### PR TITLE
Shortcodes

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -11,3 +11,82 @@ Currently, we have the following multiformat protocols:
 - [multibase](https://github.com/ipfs/specs/issues/130)
 - [multigram](https://github.com/ipfs/specs/pull/123)
 - [multikey](https://github.com/ipfs/specs/issues/58)
+
+# multihash
+
+{{% multiformat
+	syntax="<fn-code> <length> <hash-digest>"
+	labels="code of the hash function being used|varint digest size in bytes|hash function output"
+	example="QmYtUc4iTCbbfVSDNKvtQqrfyezPPnFvE33wFmutw9PBBk"
+	description=""
+%}}
+
+-----
+
+{{% multihash
+	input="hello world"
+	fnCode="17"
+	name="sha1"
+	length="11"
+	digest="68656c6c6f20776f726c64"
+	fullHash="110b68656c6c6f20776f726c64"
+%}}
+
+{{% multihash
+	fnCode="18"
+	name="sha2-256"
+	length="11"
+	digest="68656c6c6f20776f726c64"
+	fullHash="120b68656c6c6f20776f726c64"
+%}}
+
+{{% multihash
+	fnCode="64"
+	name="blake2b"
+	length="11"
+	digest="68656c6c6f20776f726c64"
+	fullHash="400b68656c6c6f20776f726c64"
+%}}
+
+{{% multihash
+	fnCode="65"
+	name="blake2s"
+	length="11"
+	digest="68656c6c6f20776f726c64"
+	fullHash="410b68656c6c6f20776f726c64"
+%}}
+
+# multiaddr
+
+{{% multiformat
+	syntax="(/<addr-str-code> /<addr-str-rep>)+"
+	labels="address code as a string|the address itself"
+	example="/ipv4/127.0.0.1/tcp/4000"
+	%}}
+
+-----------------
+## notes 
+
+what
+
+
+<fn-code><length><hash-digest>
+
+ ^       ^       ^
+ |       |       |
+ |       |       +-- hash function output
+ |       |            
+ |       |
+ |       +------- varint digest size in bytes
+ |
+ +------------ code of the hash function being used
+
+
+112008e11fc41466fcda0af7dee0905605d9
+11 20 08e11fc41466fcda0af7dee0905605d9
+
+fn code
+   length
+	     hash digest
+
+hello

--- a/layouts/shortcodes/multiformat.html
+++ b/layouts/shortcodes/multiformat.html
@@ -1,0 +1,49 @@
+{{ $syntax := .Get "syntax" }}
+{{ $labels := .Get "labels" }}
+<style>
+code {
+	display: inline-block;
+	padding: 0px;
+}
+.c-0, .c-1, .c-2 {
+	color: white;
+}
+
+.c-0 {
+	color: #a155c1;
+}
+
+.c-1 {
+	color: #65ac39;
+}
+
+.c-2 {
+	color: #3845aa;
+}
+
+.label {
+	padding: 5px;
+	font-weight: bolder;
+	font-size: 20px;
+}
+
+.example {
+	font-size: 15px;
+	opacity: 0.9;
+	text-align: right;
+}
+</style>
+<div>
+<div class="example">Example: {{ .Get "example" }}</div>
+<div>
+<pre>
+{{ range $i, $e := split $syntax " "  }}<code class="c-{{$i}}">{{ $e }}</code>{{ end }}
+</pre>
+	{{/* <fn-code><length><hash-digest> */}}
+</div>
+<div>
+	{{ range $i, $e := split $labels "|"  }}
+		<div class="label c-{{$i}}">{{ $e }}</div>
+	{{ end }}
+</div>
+</div>

--- a/layouts/shortcodes/multihash.html
+++ b/layouts/shortcodes/multihash.html
@@ -1,0 +1,27 @@
+<style>
+.multihash {
+	margin-top: 50px;
+}
+</style>
+<div class='multihash'>
+	{{ with .Get "input" }}
+	<div>
+		Input: {{ . }}
+	</div>
+	{{ end }}
+	<div>
+		Hashing function: {{ .Get "name" }}
+	</div>
+	<div>
+		Code: {{ .Get "fnCode" }}
+	</div>
+	<div>
+		Length: {{ .Get "length" }}
+	</div>
+	<div>
+		Result: <span class="c-0">{{ .Get "fnCode" }}</span><span class="c-1">{{ .Get "length" }}</span><span class="c-2">{{ .Get "digest" }}</span>
+	</div>
+	<div>
+		Result: {{ .Get "fullHash" }}
+	</div>
+</div>

--- a/list-multihashes.js
+++ b/list-multihashes.js
@@ -1,0 +1,15 @@
+const multihashes = require('multihashes')
+const buf = new Buffer('hello world')
+
+const funcs = ['sha1', 'sha2-256', 'blake2b', 'blake2s']
+
+for (const i in funcs) {
+  const encoded = multihashes.encode(buf, funcs[i])
+  const decoded = multihashes.decode(encoded)
+  console.log('HASH: ' + encoded.toString('hex'))
+  console.log('name: ' + decoded.name)
+  console.log('code: ' + decoded.code)
+  console.log('length: ' + decoded.length)
+  console.log('digest: ' + decoded.digest.toString('hex'))
+  console.log('=======')
+}


### PR DESCRIPTION
Based on the branch `fresh` with additional shortcodes for multiformats and multihashes. Initial version.

<img width="630" alt="image" src="https://cloud.githubusercontent.com/assets/459764/23282928/b4ca11aa-fa23-11e6-9fbc-a7248d87cbda.png">

As you can see in the picture, I'm clearly missing something from the multihash I get from js-multihash or the way I manually putting them together