### PR TITLE
Add Swift client to list of multiaddr implementations

### DIFF
--- a/content/multiaddr.md
+++ b/content/multiaddr.md
@@ -94,6 +94,7 @@ These implementations are available:
 - [cs-multiaddress](https://github.com/tabrath/cs-multiaddress) - alpha
 - [erlang-multiaddr](https://github.com/helium/erlang-multiaddr) - alpha
 - [net-ipfs-core](https://github.com/richardschneider/net-ipfs-core) - stable
+- [swift-multiaddr](https://github.com/lukereichold/swift-multiaddr) - stable
 - [(add yours here)](https://github.com/multiformats/website/blob/master/content/multiaddr.md)
 
 ## Examples


### PR DESCRIPTION
Submitting here also so that there is parity between the clients listed on the website and on the main multiaddr repo. Echoes [PR #98 from the multiaddr repo](https://github.com/multiformats/multiaddr/pull/98) that's been approved and merged.

> I've written a multiaddr client in Swift. As compared to the existing client, this version (https://github.com/lukereichold/swift-multiaddr) offers the following:
> - Swift Package Manager (SPM) support
> - Written in modern, idiomatic Swift
> - Eliminates need for external dependencies
> - Greater protocol support
>
> Thanks!