### PR TITLE
Clarify the status of projects

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -29,10 +29,10 @@ The self-describing aspects of the protocols have a few stipulations:
 Currently, we have the following multiformat protocols:
 
 - [multihash](./multihash) - self-describing <span class="mfc mfc-multihash">hashes</span>
-- [multiaddr](./multiaddr) - self-describing <span class="mfc mfc-multiaddr">network addresses</span>
-- [multibase](https://github.com/multiformats/multibase) - self-describing <span class="mfc mfc-multibase">base encodings</span>
+- [multiaddr](./multiaddr)  <small>(WIP)</small> - self-describing <span class="mfc mfc-multiaddr">network addresses</span>
+- [multibase](https://github.com/multiformats/multibase)  <small>(WIP)</small> - self-describing <span class="mfc mfc-multibase">base encodings</span>
 - [multicodec](https://github.com/multiformats/multicodec) - self-describing <span class="mfc mfc-multicodec">serialization</span>
-- [multistream](https://github.com/multiformats/multistream) - self-describing <span class="mfc mfc-multistream">stream network protocols</span>
+- [multistream](https://github.com/multiformats/multistream) <small>(DEPRECATED)</small> - self-describing <span class="mfc mfc-multistream">stream network protocols</span>
 - [multigram](https://github.com/multiformats/multigram) <small>(WIP)</small> - self-describing <span class="mfc mfc-multigram">packet network protocols</span>
 
 <!--

--- a/content/index.md
+++ b/content/index.md
@@ -26,7 +26,7 @@ The self-describing aspects of the protocols have a few stipulations:
 
 ## Multiformat protocols
 
-Currently, we have the following multiformat protocols:
+Currently, the following multiformat protocols exist:
 
 - [multihash](./multihash) - self-describing <span class="mfc mfc-multihash">hashes</span>
 - [multiaddr](./multiaddr)  <small>(WIP)</small> - self-describing <span class="mfc mfc-multiaddr">network addresses</span>


### PR DESCRIPTION
Specifications in draft/WIP status should be referenced as such.