### PR TITLE
Fix Blake2 examples

### DIFF
--- a/content/multihash.md
+++ b/content/multihash.md
@@ -103,6 +103,7 @@ The multihash examples are chosen to show different hash functions and different
 {{% multihash
   fnName="sha1"
   fnCode="11"
+  fnCodeVarint="11"
   length="20"
   lengthCode="14"
   digest="8a173fd3e32c0fa78b90fe42d305f202244e2739"
@@ -114,6 +115,7 @@ The multihash examples are chosen to show different hash functions and different
 {{% multihash
   fnName="sha2-256"
   fnCode="12"
+  fnCodeVarint="12"
   length="32"
   lengthCode="20"
   digest="41dd7b6443542e75701aa98a0c235951a28a0d851b11564d20022ab11d2589a8"
@@ -125,6 +127,7 @@ The multihash examples are chosen to show different hash functions and different
 {{% multihash
   fnName="sha2-512"
   fnCode="13"
+  fnCodeVarint="13"
   length="32"
   lengthCode="20"
   digest="52eb4dd19f1ec522859e12d89706156570f8fbab1824870bc6f8c7d235eef5f4"
@@ -138,6 +141,7 @@ Note: this is the actual SHA-512 (as per code `0x13`) truncated to 256 bits; som
 {{% multihash
   fnName="sha2-512"
   fnCode="13"
+  fnCodeVarint="13"
   length="64"
   lengthCode="40"
   digest="52eb4dd19f1ec522859e12d89706156570f8fbab1824870bc6f8c7d235eef5f4c2cbbafd365f96fb12b1d98a0334870c2ce90355da25e6a1108a6e17c4aaebb0"
@@ -149,6 +153,7 @@ Note: this is the actual SHA-512 (as per code `0x13`) truncated to 256 bits; som
 {{% multihash
   fnName="blake2b-512"
   fnCode="b240"
+  fnCodeVarint="c0e402"
   length="64"
   lengthCode="40"
   digest="d91ae0cb0e48022053ab0f8f0dc78d28593d0f1c13ae39c9b169c136a779f21a0496337b6f776a73c1742805c1cc15e792ddb3c92ee1fe300389456ef3dc97e2"
@@ -160,6 +165,7 @@ Note: this is the actual SHA-512 (as per code `0x13`) truncated to 256 bits; som
 {{% multihash
   fnName="blake2b-256"
   fnCode="b220"
+  fnCodeVarint="a0e402"
   length="32"
   lengthCode="20"
   digest="7d0a1371550f3306532ff44520b649f8be05b72674e46fc24468ff74323ab030"
@@ -171,6 +177,7 @@ Note: this is the actual SHA-512 (as per code `0x13`) truncated to 256 bits; som
 {{% multihash
   fnName="blake2s-256"
   fnCode="b260"
+  fnCodeVarint="e0e402"
   length="32"
   lengthCode="20"
   digest="a96953281f3fd944a3206219fad61a40b992611b7580f1fa091935db3f7ca13d"
@@ -182,6 +189,7 @@ Note: this is the actual SHA-512 (as per code `0x13`) truncated to 256 bits; som
 {{% multihash
   fnName="blake2s-128"
   fnCode="b250"
+  fnCodeVarint="d0e402"
   length="16"
   lengthCode="10"
   digest="0a4ec6f1629e49262d7093e2f82a3278"

--- a/layouts/shortcodes/multihash.html
+++ b/layouts/shortcodes/multihash.html
@@ -5,10 +5,10 @@
 <div class="multihash">
 	<div>
 		<pre class="example-code">
-<code class="c-0">{{ .Get "fnCode" }}</code><code class="c-1">{{ .Get "lengthCode" }}</code><code class="c-2">{{ .Get "digest" }}</code></pre>
+<code class="c-0">{{ .Get "fnCodeVarint" }}</code><code class="c-1">{{ .Get "lengthCode" }}</code><code class="c-2">{{ .Get "digest" }}</code></pre>
 	</div>
 	<div class="example-legend">
-		<div class="label c-0">Hashing function: <code class="c-0">{{ .Get "fnName" }}</code> (code in hex: <code>0x{{ .Get "fnCode" }}</code>)</code></div>
+		<div class="label c-0">Hashing function encoded as varint: <code class="c-0">{{ .Get "fnName" }}</code> (code in hex: <code>0x{{ .Get "fnCode" }}</code>)</code></div>
 		<div class="label c-1">Length: {{ .Get "length" }} (in hex: <code class="c-1">0x{{ .Get "lengthCode" }}</code>)</div>
 		<div class="label c-2">Digest: <code class="c-2">{{ .Get "digest" }}</code></div>
 	</div>

--- a/list-multihashes.js
+++ b/list-multihashes.js
@@ -1,7 +1,8 @@
 const multihash = require('multihashes')
 const multihashing = require('multihashing')
+const varint = require('varint')
 
-const buf = new Buffer('Merkle–Damgård', 'utf8')
+const buf = Buffer.from('Merkle–Damgård', 'utf8')
 
 const funcs = [
   ['sha1', 160],
@@ -18,11 +19,17 @@ for (const i in funcs) {
   const encoded = multihashing(buf, funcs[i][0], funcs[i][1] / 8)
   const decoded = multihash.decode(encoded)
 
+  // Decode start of the hash to get the number of bytes the codec takes
+  varint.decode(encoded)
+  const encodedCodeSize = varint.decode.bytes
+  const fnCodeVarint = encoded.slice(0, encodedCodeSize)
+
   console.log('### ' + decoded.name + ' - ' + (decoded.length * 8) + ' bits')
   console.log('')
   console.log('{{% multihash')
   console.log('  fnName="' + decoded.name + '"')
   console.log('  fnCode="' + decoded.code.toString(16) + '"')
+  console.log('  fnCodeVarint="' + fnCodeVarint.toString('hex') + '"')
   console.log('  length="' + decoded.length + '"')
   console.log('  lengthCode="' + decoded.length.toString(16) + '"')
   console.log('  digest="' + decoded.digest.toString('hex') + '"')


### PR DESCRIPTION
The examples using Blake2 were wrong. The code is encoded as varint.

Fixes #23.