### PR TITLE
Fix missing hash-func-type part in the 1st example

### DIFF
--- a/content/multihash.md
+++ b/content/multihash.md
@@ -56,6 +56,7 @@ For example:
 {{% multihash
   fnName="sha2-256"
   fnCode="12"
+  fnCodeVarint="12"
   length="32"
   lengthCode="20"
   digest="41dd7b6443542e75701aa98a0c235951a28a0d851b11564d20022ab11d2589a8"


### PR DESCRIPTION
The `fnCodeVarint` should be defined so that the example can be rendered
correctly.

Before:
![Screen Shot 2020-05-09 at 11 12 30 AM](https://user-images.githubusercontent.com/13881324/81477524-26579100-91e6-11ea-952a-8dc363c4d7ef.png)

After:
![Screen Shot 2020-05-09 at 11 13 01 AM](https://user-images.githubusercontent.com/13881324/81477530-2b1c4500-91e6-11ea-9eea-5c1f87ae2d53.png)
