### PR TITLE
rename Libra to Diem

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -72,9 +72,9 @@ The Multiformats project began through [the IPFS Project](https://ipfs.io). It i
 		- a set of standards and implementations for creating decentralized data-structures that are universally addressable and linkable.
 	</li>
 	<li>
-		<a href="https://github.com/libra/libra">
-		<img height="64px" src="https://github.com/libra/libra/raw/master/.assets/libra.png" />Libra</a>
-		- Libra’s mission is to enable a simple global currency and financial infrastructure that empowers billions of people.
+		<a href="https://github.com/diem/diem">
+		<img height="64px" src="https://github.com/diem/diem/raw/master/.assets/diem.png" />Diem</a>
+		- Diem’s mission is to enable a simple global currency and financial infrastructure that empowers billions of people.
 	</li>
 	<li>
 		<a href="https://github.com/NamChain-Open-Initiative-Research-Lab/NamChain">


### PR DESCRIPTION
Found when trying to visit the old Libra repo: 

Note to readers: On December 1, 2020, the Libra Association was renamed to Diem Association. The project repos are in the process of being migrated. All projects will remain available for use here until the migration to a new GitHub Organization is complete.

Note that IPLD logo isn't displaying properly on this site. IPFS and libp2p logos display for me on the site but not in this GitHub preview.